### PR TITLE
Add tests for reproducing `LobattoLegendre`-`GaussRadauRight` operators with subcell operators

### DIFF
--- a/test/test_subcell_reproducing.jl
+++ b/test/test_subcell_reproducing.jl
@@ -57,5 +57,5 @@ end
 end
 
 @testitem "Reproducing LobattoLegendre and GaussRadauRight" setup=[ReproducingSubcell1D] begin
-    test_reproducing(LobattoLegendre, GaussRadauRight, 0.0; atol = 1e-11)
+    test_reproducing(LobattoLegendre, GaussRadauRight, 0.0; atol = 1e-10)
 end


### PR DESCRIPTION
Interestingly, `LobattoLegendre` in the left and `GaussRadauRight` in the right subcell, needs `x_M = 0` to converge to the operators in each subcell.