### PR TITLE
Shorten extension names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,10 +28,10 @@ Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
 [extensions]
-SummationByPartsOperatorsExtraManifoldsManoptForwardDiffExt = ["Manifolds", "Manopt", "ForwardDiff", "RecursiveArrayTools"]
-SummationByPartsOperatorsExtraMeshesExt = "Meshes"
-SummationByPartsOperatorsExtraMeshesMakieExt = ["Meshes", "Makie"]
-SummationByPartsOperatorsExtraOptimForwardDiffExt = ["Optim", "ForwardDiff"]
+ManifoldsManoptForwardDiffExt = ["Manifolds", "Manopt", "ForwardDiff", "RecursiveArrayTools"]
+ExtraMeshesExt = "Meshes"
+MeshesMakieExt = ["Meshes", "Makie"]
+OptimForwardDiffExt = ["Optim", "ForwardDiff"]
 
 [compat]
 ArgCheck = "1, 2"

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
 [extensions]
 ManifoldsManoptForwardDiffExt = ["Manifolds", "Manopt", "ForwardDiff", "RecursiveArrayTools"]
-ExtraMeshesExt = "Meshes"
+MeshesExt = "Meshes"
 MeshesMakieExt = ["Meshes", "Makie"]
 OptimForwardDiffExt = ["Optim", "ForwardDiff"]
 

--- a/ext/ManifoldsManoptForwardDiffExt.jl
+++ b/ext/ManifoldsManoptForwardDiffExt.jl
@@ -1,4 +1,4 @@
-module SummationByPartsOperatorsExtraManifoldsManoptForwardDiffExt
+module ManifoldsManoptForwardDiffExt
 
 using Manifolds: Manifolds, SkewSymmetricMatrices, PositiveVectors, ProductManifold,
                  check_point

--- a/ext/MeshesExt.jl
+++ b/ext/MeshesExt.jl
@@ -1,4 +1,4 @@
-module SummationByPartsOperatorsExtraMeshesExt
+module MeshesExt
 
 using Meshes: Meshes, PointSet, Geometry, Point, Ring, Sphere,
               paramdim, sample, boundary, measure, to, integral

--- a/ext/MeshesMakieExt.jl
+++ b/ext/MeshesMakieExt.jl
@@ -1,4 +1,4 @@
-module SummationByPartsOperatorsExtraMeshesMakieExt
+module MeshesMakieExt
 
 using LinearAlgebra: Symmetric
 using Meshes: Meshes, PointSet, coords, viz, viz!

--- a/ext/OptimForwardDiffExt.jl
+++ b/ext/OptimForwardDiffExt.jl
@@ -1,4 +1,4 @@
-module SummationByPartsOperatorsExtraOptimForwardDiffExt
+module OptimForwardDiffExt
 
 using Optim: Optim, Options, BFGS, optimize, minimizer
 import ForwardDiff


### PR DESCRIPTION
With the latest julia v1.12 and also in julia v1.13 (v1.10 is not supported anyway) the package name is always printed together with the extension name (see https://github.com/JuliaLang/julia/pull/60456). Since the full names are currently pretty long, I think it makes sense to remove the additional "SummationByPartsOperatorsExtra" part.